### PR TITLE
Type conversion for custom port

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ let config = {
     connect: {
         server: process.env["SERVER"],
         options :{
-            port: process.env["PORT"] || 1433,
+            port: parseInt(process.env["PORT"]) || 1433,
             encrypt:process.env["ENCRYPT"]=="false" ? false: true,
             rowCollectionOnRequestCompletion: true
         },

--- a/metrics.js
+++ b/metrics.js
@@ -6,7 +6,7 @@ const debug = require("debug")("metrics");
 const client = require('prom-client');
 
 // UP metric
-const up = new client.Gauge({name: 'up', help: "UP Status"});
+const up = new client.Gauge({name: 'mssql_up', help: "UP Status"});
 
 // Query based metrics
 // -------------------


### PR DESCRIPTION
Because the "config.options.port" property must be of type number.  but get variable from env is string by default